### PR TITLE
Add Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV HOME=/workspace/
+ENV THE_PREFIX=/usr/
+RUN apt update
+RUN apt install -y libgtest-dev libgmp-dev build-essential cmake \
+    python3 python-is-python3 wget autoconf perl flex bison zlib1g-dev \
+    libgflags-dev libgoogle-glog-dev libprotobuf-dev libboost-all-dev \
+    libssl-dev help2man
+COPY . .
+RUN ./install_systemc.sh

--- a/docker/install_systemc.sh
+++ b/docker/install_systemc.sh
@@ -1,0 +1,9 @@
+
+NPROC=4
+
+# install systemc
+wget https://github.com/accellera-official/systemc/archive/refs/tags/2.3.4.tar.gz -O systemc.tar.gz && \
+tar zxf systemc.tar.gz && cd systemc-2.3.4 && \
+cmake -DCMAKE_INSTALL_PREFIX=${THE_PREFIX} -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 && \
+	${SUDO} make -j${NPROC} install
+exit 0


### PR DESCRIPTION
Add a folder "docker".
In /docker, add files Dockerfile, install_systemc.sh The Dockerfile should install libraries which we might required.

Dockerfile:
ubuntu: 22.04
install: (not all listed) gtest, gmp, cmake, python, glog, ssl, ... run: install_systemc.sh

install_systemc.sh:
version: 2.3.4